### PR TITLE
feat: add participant info methods (avatar, persistent ID, customer k…

### DIFF
--- a/src/services/meeting_service.rs
+++ b/src/services/meeting_service.rs
@@ -22,7 +22,7 @@ pub mod webcam_interface;
 
 pub use audio_controller::AudioController;
 pub use chat_interface::ChatInterface;
-pub use participants_interface::ParticipantsInterface;
+pub use participants_interface::{AudioJoinType, ParticipantsInterface, UserRole};
 pub use recording_controller::RecordingController;
 pub use sharing_controller::SharingController;
 pub use webcam_interface::{new_webcam_injection_boitlerplate, VideoToWebcam};

--- a/src/services/meeting_service/participants_interface.rs
+++ b/src/services/meeting_service/participants_interface.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use crate::{bindings::*, SdkResult, ZoomRsError};
 
-// External C functions for new PII methods
+// External C functions for participant info methods
 extern "C" {
     /// Get the avatar file path for a user.
     pub fn meeting_participants_get_avatar_path(user_info: *mut ZOOMSDK_IUserInfo) -> *const zchar_t;
@@ -14,6 +14,20 @@ extern "C" {
     pub fn meeting_participants_get_customer_key(user_info: *mut ZOOMSDK_IUserInfo) -> *const zchar_t;
     /// Get the user role (0=NONE, 1=HOST, 2=COHOST, 3=PANELIST, 4=BREAKOUT_MODERATOR, 5=ATTENDEE).
     pub fn meeting_participants_get_user_role(user_info: *mut ZOOMSDK_IUserInfo) -> i32;
+    /// Get audio join type (0=UNKNOWN, 1=VOIP, 2=PHONE, 3=UNKNOWN_H323_OR_SIP, 4=H323, 5=SIP).
+    pub fn meeting_participants_get_audio_join_type(user_info: *mut ZOOMSDK_IUserInfo) -> i32;
+    /// Check if user is a pure phone user (dialed in, no app).
+    pub fn meeting_participants_is_pure_phone_user(user_info: *mut ZOOMSDK_IUserInfo) -> bool;
+    /// Check if user has a camera device.
+    pub fn meeting_participants_has_camera(user_info: *mut ZOOMSDK_IUserInfo) -> bool;
+    /// Check if user's audio is muted.
+    pub fn meeting_participants_is_audio_muted(user_info: *mut ZOOMSDK_IUserInfo) -> bool;
+    /// Check if user's video is on.
+    pub fn meeting_participants_is_video_on(user_info: *mut ZOOMSDK_IUserInfo) -> bool;
+    /// Check if user is in waiting room.
+    pub fn meeting_participants_is_in_waiting_room(user_info: *mut ZOOMSDK_IUserInfo) -> bool;
+    /// Check if user has hand raised.
+    pub fn meeting_participants_is_raise_hand(user_info: *mut ZOOMSDK_IUserInfo) -> bool;
 }
 
 /// Main interface to get info and to manipulate [Participant].
@@ -150,6 +164,42 @@ impl<'a> Participant<'a> {
     /// Returns: 0=NONE, 1=HOST, 2=COHOST, 3=PANELIST, 4=BREAKOUT_MODERATOR, 5=ATTENDEE
     pub fn get_user_role(&self) -> i32 {
         unsafe { meeting_participants_get_user_role(self.inner.as_ptr()) }
+    }
+
+    /// Get the audio join type of the user.
+    /// Returns: 0=UNKNOWN, 1=VOIP, 2=PHONE, 3=UNKNOWN_H323_OR_SIP, 4=H323, 5=SIP
+    pub fn get_audio_join_type(&self) -> i32 {
+        unsafe { meeting_participants_get_audio_join_type(self.inner.as_ptr()) }
+    }
+
+    /// Check if user is a pure phone user (dialed in by phone, no app).
+    pub fn is_pure_phone_user(&self) -> bool {
+        unsafe { meeting_participants_is_pure_phone_user(self.inner.as_ptr()) }
+    }
+
+    /// Check if user has a camera device.
+    pub fn has_camera(&self) -> bool {
+        unsafe { meeting_participants_has_camera(self.inner.as_ptr()) }
+    }
+
+    /// Check if user's audio is muted.
+    pub fn is_audio_muted(&self) -> bool {
+        unsafe { meeting_participants_is_audio_muted(self.inner.as_ptr()) }
+    }
+
+    /// Check if user's video is on.
+    pub fn is_video_on(&self) -> bool {
+        unsafe { meeting_participants_is_video_on(self.inner.as_ptr()) }
+    }
+
+    /// Check if user is in waiting room.
+    pub fn is_in_waiting_room(&self) -> bool {
+        unsafe { meeting_participants_is_in_waiting_room(self.inner.as_ptr()) }
+    }
+
+    /// Check if user has hand raised.
+    pub fn is_raise_hand(&self) -> bool {
+        unsafe { meeting_participants_is_raise_hand(self.inner.as_ptr()) }
     }
 }
 

--- a/src/services/meeting_service/participants_interface.rs
+++ b/src/services/meeting_service/participants_interface.rs
@@ -4,6 +4,108 @@ use std::fmt;
 
 use crate::{bindings::*, SdkResult, ZoomRsError};
 
+/// User role in a Zoom meeting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum UserRole {
+    /// No role assigned.
+    None = 0,
+    /// Meeting host.
+    Host = 1,
+    /// Co-host with elevated privileges.
+    CoHost = 2,
+    /// Panelist in a webinar.
+    Panelist = 3,
+    /// Moderator of a breakout room.
+    BreakoutModerator = 4,
+    /// Regular attendee.
+    Attendee = 5,
+}
+
+impl UserRole {
+    /// Convert from raw SDK value to enum.
+    pub fn from_raw(value: i32) -> Self {
+        match value {
+            0 => Self::None,
+            1 => Self::Host,
+            2 => Self::CoHost,
+            3 => Self::Panelist,
+            4 => Self::BreakoutModerator,
+            5 => Self::Attendee,
+            _ => Self::None,
+        }
+    }
+
+    /// Convert to a human-readable string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Host => "host",
+            Self::CoHost => "cohost",
+            Self::Panelist => "panelist",
+            Self::BreakoutModerator => "breakout_moderator",
+            Self::Attendee => "attendee",
+        }
+    }
+}
+
+impl fmt::Display for UserRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// How a user joined audio in a Zoom meeting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum AudioJoinType {
+    /// Unknown audio connection type.
+    Unknown = 0,
+    /// Voice over IP (computer audio).
+    Voip = 1,
+    /// Phone dial-in.
+    Phone = 2,
+    /// H.323 or SIP (type not yet determined).
+    UnknownH323OrSip = 3,
+    /// H.323 video conferencing protocol.
+    H323 = 4,
+    /// SIP (Session Initiation Protocol).
+    Sip = 5,
+}
+
+impl AudioJoinType {
+    /// Convert from raw SDK value to enum.
+    pub fn from_raw(value: i32) -> Self {
+        match value {
+            0 => Self::Unknown,
+            1 => Self::Voip,
+            2 => Self::Phone,
+            3 => Self::UnknownH323OrSip,
+            4 => Self::H323,
+            5 => Self::Sip,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Convert to a human-readable string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Voip => "voip",
+            Self::Phone => "phone",
+            Self::UnknownH323OrSip => "unknown_h323_or_sip",
+            Self::H323 => "h323",
+            Self::Sip => "sip",
+        }
+    }
+}
+
+impl fmt::Display for AudioJoinType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
 // External C functions for participant info methods
 extern "C" {
     /// Get the avatar file path for a user.
@@ -161,15 +263,13 @@ impl<'a> Participant<'a> {
     }
 
     /// Get the type of role of the user.
-    /// Returns: 0=NONE, 1=HOST, 2=COHOST, 3=PANELIST, 4=BREAKOUT_MODERATOR, 5=ATTENDEE
-    pub fn get_user_role(&self) -> i32 {
-        unsafe { meeting_participants_get_user_role(self.inner.as_ptr()) }
+    pub fn get_user_role(&self) -> UserRole {
+        UserRole::from_raw(unsafe { meeting_participants_get_user_role(self.inner.as_ptr()) })
     }
 
     /// Get the audio join type of the user.
-    /// Returns: 0=UNKNOWN, 1=VOIP, 2=PHONE, 3=UNKNOWN_H323_OR_SIP, 4=H323, 5=SIP
-    pub fn get_audio_join_type(&self) -> i32 {
-        unsafe { meeting_participants_get_audio_join_type(self.inner.as_ptr()) }
+    pub fn get_audio_join_type(&self) -> AudioJoinType {
+        AudioJoinType::from_raw(unsafe { meeting_participants_get_audio_join_type(self.inner.as_ptr()) })
     }
 
     /// Check if user is a pure phone user (dialed in by phone, no app).

--- a/wrapper-cpp/modules/c_meeting_participants_interface.cpp
+++ b/wrapper-cpp/modules/c_meeting_participants_interface.cpp
@@ -85,6 +85,34 @@ extern "C" int meeting_participants_get_user_role(ZOOMSDK::IUserInfo *user_info)
     return static_cast<int>(user_info->GetUserRole());
 }
 
+extern "C" int meeting_participants_get_audio_join_type(ZOOMSDK::IUserInfo *user_info) {
+    return static_cast<int>(user_info->GetAudioJoinType());
+}
+
+extern "C" bool meeting_participants_is_pure_phone_user(ZOOMSDK::IUserInfo *user_info) {
+    return user_info->IsPurePhoneUser();
+}
+
+extern "C" bool meeting_participants_has_camera(ZOOMSDK::IUserInfo *user_info) {
+    return user_info->HasCamera();
+}
+
+extern "C" bool meeting_participants_is_audio_muted(ZOOMSDK::IUserInfo *user_info) {
+    return user_info->IsAudioMuted();
+}
+
+extern "C" bool meeting_participants_is_video_on(ZOOMSDK::IUserInfo *user_info) {
+    return user_info->IsVideoOn();
+}
+
+extern "C" bool meeting_participants_is_in_waiting_room(ZOOMSDK::IUserInfo *user_info) {
+    return user_info->IsInWaitingRoom();
+}
+
+extern "C" bool meeting_participants_is_raise_hand(ZOOMSDK::IUserInfo *user_info) {
+    return user_info->IsRaiseHand();
+}
+
 extern "C" ZOOMSDK::IUserInfo *get_my_self_user(ZOOMSDK::IMeetingParticipantsController *controller) {
     return controller->GetMySelfUser();
 }

--- a/wrapper-cpp/modules/c_meeting_participants_interface.cpp
+++ b/wrapper-cpp/modules/c_meeting_participants_interface.cpp
@@ -69,6 +69,22 @@ extern "C" bool is_host(ZOOMSDK::IUserInfo *user_info) {
     return user_info->IsHost();
 }
 
+extern "C" const zchar_t* meeting_participants_get_avatar_path(ZOOMSDK::IUserInfo *user_info) {
+    return user_info->GetAvatarPath();
+}
+
+extern "C" const zchar_t* meeting_participants_get_persistent_id(ZOOMSDK::IUserInfo *user_info) {
+    return user_info->GetPersistentId();
+}
+
+extern "C" const zchar_t* meeting_participants_get_customer_key(ZOOMSDK::IUserInfo *user_info) {
+    return user_info->GetCustomerKey();
+}
+
+extern "C" int meeting_participants_get_user_role(ZOOMSDK::IUserInfo *user_info) {
+    return static_cast<int>(user_info->GetUserRole());
+}
+
 extern "C" ZOOMSDK::IUserInfo *get_my_self_user(ZOOMSDK::IMeetingParticipantsController *controller) {
     return controller->GetMySelfUser();
 }

--- a/wrapper-cpp/modules/c_meeting_participants_interface.h
+++ b/wrapper-cpp/modules/c_meeting_participants_interface.h
@@ -60,6 +60,26 @@ extern "C" unsigned int get_user_id(ZOOMSDK::IUserInfo *user_info);
 /// @return Boolean, true is the user is the host
 extern "C" bool is_host(ZOOMSDK::IUserInfo *user_info);
 
+/// @brief Get the avatar file path matched with the current user information.
+/// @param user_info A Pointer to ZOOMSDK::IUserInfo
+/// @return If the function succeeds, the return value is the avatar file path. Otherwise NULL.
+extern "C" const zchar_t* meeting_participants_get_avatar_path(ZOOMSDK::IUserInfo *user_info);
+
+/// @brief Get the user persistent id matched with the current user information.
+/// @param user_info A Pointer to ZOOMSDK::IUserInfo
+/// @return If the function succeeds, the return value is the user persistent id. Otherwise NULL.
+extern "C" const zchar_t* meeting_participants_get_persistent_id(ZOOMSDK::IUserInfo *user_info);
+
+/// @brief Get the customer_key matched with the current user information.
+/// @param user_info A Pointer to ZOOMSDK::IUserInfo
+/// @return If the function succeeds, the return value is the customer_key. Otherwise NULL.
+extern "C" const zchar_t* meeting_participants_get_customer_key(ZOOMSDK::IUserInfo *user_info);
+
+/// @brief Get the type of role of the user specified by the current information.
+/// @param user_info A Pointer to ZOOMSDK::IUserInfo
+/// @return The role of the user (0=NONE, 1=HOST, 2=COHOST, 3=PANELIST, 4=BREAKOUT_MODERATOR, 5=ATTENDEE)
+extern "C" int meeting_participants_get_user_role(ZOOMSDK::IUserInfo *user_info);
+
 /// \brief Get the information of current user.
 /// \return If the function succeeds, the return value is a pointer to the IUserInfo. For more details, see \link IUserInfo \endlink.
 /// Otherwise failed, the return value is NULL.

--- a/wrapper-cpp/modules/c_meeting_participants_interface.h
+++ b/wrapper-cpp/modules/c_meeting_participants_interface.h
@@ -80,6 +80,41 @@ extern "C" const zchar_t* meeting_participants_get_customer_key(ZOOMSDK::IUserIn
 /// @return The role of the user (0=NONE, 1=HOST, 2=COHOST, 3=PANELIST, 4=BREAKOUT_MODERATOR, 5=ATTENDEE)
 extern "C" int meeting_participants_get_user_role(ZOOMSDK::IUserInfo *user_info);
 
+/// @brief Get the audio type of the user when joining the meeting.
+/// @param user_info A Pointer to ZOOMSDK::IUserInfo
+/// @return The audio join type (0=CYCXING_AUDIO_TYPE_UNKNOWN, 1=CYCXING_AUDIO_TYPE_VOIP, 2=CYCXING_AUDIO_TYPE_PHONE, 3=CYCXING_AUDIO_TYPE_UNKNOW_H323_OR_SIP, 4=CYCXING_AUDIO_TYPE_H323, 5=CYCXING_AUDIO_TYPE_SIP)
+extern "C" int meeting_participants_get_audio_join_type(ZOOMSDK::IUserInfo *user_info);
+
+/// @brief Check if a participant is a pure phone user (dialed in, no app).
+/// @param user_info A Pointer to ZOOMSDK::IUserInfo
+/// @return Boolean, true if the user joined by phone only
+extern "C" bool meeting_participants_is_pure_phone_user(ZOOMSDK::IUserInfo *user_info);
+
+/// @brief Check if a participant has a camera device.
+/// @param user_info A Pointer to ZOOMSDK::IUserInfo
+/// @return Boolean, true if the user has a camera
+extern "C" bool meeting_participants_has_camera(ZOOMSDK::IUserInfo *user_info);
+
+/// @brief Check if a participant's audio is muted.
+/// @param user_info A Pointer to ZOOMSDK::IUserInfo
+/// @return Boolean, true if the user's audio is muted
+extern "C" bool meeting_participants_is_audio_muted(ZOOMSDK::IUserInfo *user_info);
+
+/// @brief Check if a participant's video is on.
+/// @param user_info A Pointer to ZOOMSDK::IUserInfo
+/// @return Boolean, true if the user's video is on
+extern "C" bool meeting_participants_is_video_on(ZOOMSDK::IUserInfo *user_info);
+
+/// @brief Check if a participant is in the waiting room.
+/// @param user_info A Pointer to ZOOMSDK::IUserInfo
+/// @return Boolean, true if the user is in the waiting room
+extern "C" bool meeting_participants_is_in_waiting_room(ZOOMSDK::IUserInfo *user_info);
+
+/// @brief Check if a participant has their hand raised.
+/// @param user_info A Pointer to ZOOMSDK::IUserInfo
+/// @return Boolean, true if the user has their hand raised
+extern "C" bool meeting_participants_is_raise_hand(ZOOMSDK::IUserInfo *user_info);
+
 /// \brief Get the information of current user.
 /// \return If the function succeeds, the return value is a pointer to the IUserInfo. For more details, see \link IUserInfo \endlink.
 /// Otherwise failed, the return value is NULL.


### PR DESCRIPTION
…ey, role)

Add new methods to retrieve additional participant information:
- get_avatar_path(): Get the avatar file path for a user
- get_persistent_id(): Get the unique identifier that persists across meetings
- get_customer_key(): Get the custom key assigned in join parameters
- get_user_role(): Get the user's role (HOST, COHOST, PANELIST, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)